### PR TITLE
Add static web client for GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,30 @@ docker compose up --build
 # UI: http://localhost:8501  API: http://localhost:8000
 ```
 
+## Static web deployment (GitHub Pages friendly)
+
+The repository ships with a zero-dependency browser client under `ui/web`. It speaks directly to the FastAPI backend over CORS, so you can expose the full workflow (health check, document ingest, Q&A with previews) from any static host.
+
+### Local preview
+
+```bash
+python -m http.server 8080 --directory ui/web
+# Open http://localhost:8080 and point it at your API
+```
+
+### GitHub Pages (recommended)
+
+1. Decide where the API will live. When serving the static page from an HTTPS origin (GitHub Pages), the API should also be reachable over HTTPS to avoid mixed-content blocking.
+2. Copy the contents of `ui/web/` into a `docs/` folder (or your `gh-pages` branch) and enable GitHub Pages for that path.
+3. Visit the published page, set the **API base URL** in the banner (or append `?api=https://your-api.example.com` to the URL). The setting is cached in localStorage for returning operators.
+
+The web client mirrors the Streamlit feature set:
+
+- `/healthz` probe with visual badges for storage/OCR status.
+- ZIP or server-folder ingest with OCR toggle.
+- Project registry viewer (backed by `/projects`).
+- Retrieval UI that streams `/ask` answers and renders `/page_preview` images inline.
+
 ## OCR (optional)
 
 - macOS: `brew install tesseract`

--- a/ui/web/app.js
+++ b/ui/web/app.js
@@ -1,0 +1,399 @@
+const DEFAULT_API_BASE = (() => {
+  if (typeof window !== "undefined" && window.API_BASE) {
+    return window.API_BASE;
+  }
+  return "http://localhost:8000";
+})();
+
+let apiBase = "";
+
+const elements = {};
+
+function cacheElements() {
+  elements.apiBaseInput = document.getElementById("apiBase");
+  elements.saveApiBase = document.getElementById("saveApiBase");
+  elements.healthStatus = document.getElementById("healthStatus");
+  elements.ingestForm = document.getElementById("ingestForm");
+  elements.ingestStatus = document.getElementById("ingestStatus");
+  elements.ingestProjectId = document.getElementById("ingestProjectId");
+  elements.zipUpload = document.getElementById("zipUpload");
+  elements.folderPath = document.getElementById("folderPath");
+  elements.ocrToggle = document.getElementById("ocrToggle");
+  elements.refreshProjects = document.getElementById("refreshProjects");
+  elements.projectsTable = document.getElementById("projectsTable");
+  elements.askForm = document.getElementById("askForm");
+  elements.askStatus = document.getElementById("askStatus");
+  elements.askProjectId = document.getElementById("askProjectId");
+  elements.question = document.getElementById("question");
+  elements.topK = document.getElementById("topK");
+  elements.answer = document.getElementById("answer");
+  elements.projectRowTemplate = document.getElementById("projectRowTemplate");
+  elements.citationTemplate = document.getElementById("citationTemplate");
+}
+
+function sanitizeBase(url) {
+  if (!url) return "";
+  const trimmed = url.trim();
+  if (!trimmed) return "";
+  return trimmed.replace(/\/$/, "");
+}
+
+function setStatus(element, message, level = "") {
+  if (!element) return;
+  element.textContent = message || "";
+  element.className = "status";
+  if (message && level) {
+    element.classList.add(level);
+  }
+}
+
+function setApiBase(next) {
+  apiBase = sanitizeBase(next);
+  if (apiBase) {
+    localStorage.setItem("apiBase", apiBase);
+  } else {
+    localStorage.removeItem("apiBase");
+  }
+  elements.apiBaseInput.value = apiBase;
+}
+
+function getApiBase() {
+  return apiBase;
+}
+
+async function fetchJson(path, options = {}) {
+  const base = getApiBase();
+  if (!base) {
+    throw new Error("API base URL is not configured");
+  }
+  const response = await fetch(`${base}${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${response.status} ${response.statusText}: ${text}`);
+  }
+  const contentType = response.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return response.json();
+  }
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`Unexpected response: ${text}`);
+  }
+}
+
+function renderHealth(data) {
+  const container = elements.healthStatus;
+  container.className = "status success";
+  container.innerHTML = "";
+  if (!data) {
+    container.textContent = "Health check returned no payload.";
+    return;
+  }
+  const strip = document.createElement("div");
+  strip.className = "badge-strip";
+  const badges = [
+    { label: "API reachable", ok: true },
+    { label: "Chroma writable", ok: Boolean(data.chroma) },
+    { label: "OCR detected", ok: Boolean(data.ocr) },
+  ];
+  badges.forEach((item) => {
+    const badge = document.createElement("span");
+    badge.className = `badge ${item.ok ? "ok" : "warn"}`;
+    badge.textContent = `${item.ok ? "✅" : "⚠️"} ${item.label}`;
+    strip.appendChild(badge);
+  });
+  container.appendChild(strip);
+  const meta = document.createElement("p");
+  meta.className = "meta";
+  meta.append("Embedding model: ");
+  const code = document.createElement("code");
+  code.textContent = data.embedding_model || "unknown";
+  meta.appendChild(code);
+  meta.append(" • Docs indexed: ");
+  const strong = document.createElement("strong");
+  strong.textContent = `${data.docs_indexed ?? "0"}`;
+  meta.appendChild(strong);
+  container.appendChild(meta);
+}
+
+async function refreshHealth() {
+  if (!getApiBase()) {
+    setStatus(elements.healthStatus, "Set API base URL to check status.", "info");
+    return;
+  }
+  setStatus(elements.healthStatus, "Pinging /healthz…", "info");
+  try {
+    const data = await fetchJson("/healthz");
+    renderHealth(data);
+  } catch (error) {
+    setStatus(elements.healthStatus, `Health check failed: ${error.message}`, "error");
+  }
+}
+
+function renderProjects(projects) {
+  const container = elements.projectsTable;
+  container.innerHTML = "";
+  if (!Array.isArray(projects) || projects.length === 0) {
+    const p = document.createElement("p");
+    p.className = "hint";
+    p.textContent = "No tracked projects yet. Ingest docs to populate the index.";
+    container.appendChild(p);
+    return;
+  }
+  const template = elements.projectRowTemplate;
+  projects.forEach((proj) => {
+    const fragment = template.content.cloneNode(true);
+    fragment.querySelector(".project-id").textContent = proj.project_id;
+    fragment.querySelector(".doc-count").textContent = `${proj.docs?.length ?? 0} files`;
+    fragment.querySelector(".chunk-count").textContent = `${proj.chunks ?? 0} chunks`;
+    fragment
+      .querySelector(".doc-list")
+      .textContent = Array.isArray(proj.docs) && proj.docs.length ? proj.docs.join(", ") : "—";
+    container.appendChild(fragment);
+  });
+}
+
+async function loadProjects() {
+  if (!getApiBase()) {
+    elements.projectsTable.innerHTML = "";
+    const p = document.createElement("p");
+    p.className = "hint";
+    p.textContent = "Set API base URL to query tracked projects.";
+    elements.projectsTable.appendChild(p);
+    return;
+  }
+  elements.projectsTable.textContent = "Loading projects…";
+  try {
+    const projects = await fetchJson("/projects");
+    renderProjects(projects);
+  } catch (error) {
+    elements.projectsTable.textContent = `Failed to load projects: ${error.message}`;
+  }
+}
+
+function setProjectId(pid) {
+  const value = (pid || "").trim();
+  elements.ingestProjectId.value = value;
+  elements.askProjectId.value = value;
+  if (value) {
+    localStorage.setItem("projectId", value);
+  }
+}
+
+function clearAnswer() {
+  elements.answer.innerHTML = "";
+}
+
+function showAnswer(result, projectId) {
+  clearAnswer();
+  if (!result) {
+    return;
+  }
+  const answerHeading = document.createElement("h3");
+  answerHeading.textContent = "Answer";
+  const answerBody = document.createElement("p");
+  answerBody.textContent = result.answer || "No answer returned.";
+  elements.answer.appendChild(answerHeading);
+  elements.answer.appendChild(answerBody);
+  const citations = Array.isArray(result.citations) ? result.citations : [];
+  if (citations.length === 0) {
+    const hint = document.createElement("p");
+    hint.className = "hint";
+    hint.textContent = "No citations were returned for this answer.";
+    elements.answer.appendChild(hint);
+    return;
+  }
+  const citeHeading = document.createElement("h4");
+  citeHeading.textContent = "Citations";
+  elements.answer.appendChild(citeHeading);
+  const template = elements.citationTemplate;
+  citations.forEach((cite) => {
+    const fragment = template.content.cloneNode(true);
+    const section = fragment.querySelector(".citation");
+    const text = section.querySelector(".citation-text");
+    const score = typeof cite.score === "number" ? cite.score.toFixed(2) : "n/a";
+    text.textContent = `${cite.source} p.${cite.page} (score ${score})`;
+    const img = section.querySelector(".citation-preview");
+    const params = new URLSearchParams({
+      source: cite.source,
+      page: String(cite.page),
+      project_id: projectId,
+    });
+    img.src = `${getApiBase()}/page_preview?${params.toString()}&t=${Date.now()}`;
+    img.alt = `${cite.source} page ${cite.page}`;
+    img.addEventListener("error", () => {
+      img.remove();
+      const fallback = document.createElement("p");
+      fallback.className = "hint";
+      fallback.textContent = "Preview unavailable (check API logs).";
+      section.appendChild(fallback);
+    });
+    elements.answer.appendChild(fragment);
+  });
+}
+
+async function handleIngest(event) {
+  event.preventDefault();
+  if (!getApiBase()) {
+    setStatus(elements.ingestStatus, "Set API base URL before ingesting documents.", "error");
+    return;
+  }
+  const submit = elements.ingestForm.querySelector('button[type="submit"]');
+  submit.disabled = true;
+  const originalLabel = submit.textContent;
+  submit.textContent = "Sending…";
+  setStatus(elements.ingestStatus, "Uploading bundle to API…", "info");
+  const file = elements.zipUpload.files[0];
+  const folder = elements.folderPath.value.trim();
+  if (!file && !folder) {
+    setStatus(elements.ingestStatus, "Provide a ZIP of PDFs or a server folder path.", "error");
+    submit.disabled = false;
+    submit.textContent = originalLabel;
+    return;
+  }
+  const formData = new FormData();
+  if (file) {
+    formData.append("zipfile", file, file.name);
+  }
+  if (folder) {
+    formData.append("folder_path", folder);
+  }
+  const requestedProjectId = elements.ingestProjectId.value.trim();
+  if (requestedProjectId) {
+    formData.append("project_id", requestedProjectId);
+  }
+  formData.append("ocr", elements.ocrToggle.checked ? "true" : "false");
+  try {
+    const response = await fetch(`${getApiBase()}/ingest`, {
+      method: "POST",
+      body: formData,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || response.statusText);
+    }
+    const data = await response.json();
+    setStatus(
+      elements.ingestStatus,
+      `Ingested ${data.files} files / ${data.pages} pages → ${data.chunks} chunks (project ${data.project_id}).`,
+      "success"
+    );
+    setProjectId(data.project_id);
+    await loadProjects();
+  } catch (error) {
+    setStatus(elements.ingestStatus, `Ingest failed: ${error.message}`, "error");
+  } finally {
+    submit.disabled = false;
+    submit.textContent = originalLabel;
+  }
+}
+
+async function handleAsk(event) {
+  event.preventDefault();
+  if (!getApiBase()) {
+    setStatus(elements.askStatus, "Set API base URL before asking questions.", "error");
+    return;
+  }
+  const projectId = elements.askProjectId.value.trim();
+  const question = elements.question.value.trim();
+  const topK = Number(elements.topK.value || 5);
+  if (!projectId) {
+    setStatus(elements.askStatus, "Project ID is required.", "error");
+    return;
+  }
+  if (!question) {
+    setStatus(elements.askStatus, "Enter a question to query the index.", "error");
+    return;
+  }
+  const submit = elements.askForm.querySelector('button[type="submit"]');
+  submit.disabled = true;
+  const originalLabel = submit.textContent;
+  submit.textContent = "Querying…";
+  setStatus(elements.askStatus, "Running retrieval…", "info");
+  clearAnswer();
+  try {
+    const payload = {
+      project_id: projectId,
+      question,
+      top_k: Math.max(1, Math.min(50, topK || 5)),
+    };
+    const result = await fetchJson("/ask", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    setStatus(elements.askStatus, "Answer ready.", "success");
+    showAnswer(result, projectId);
+    setProjectId(projectId);
+  } catch (error) {
+    setStatus(elements.askStatus, `Query failed: ${error.message}`, "error");
+  } finally {
+    submit.disabled = false;
+    submit.textContent = originalLabel;
+  }
+}
+
+function bindEvents() {
+  elements.saveApiBase.addEventListener("click", () => {
+    const candidate = elements.apiBaseInput.value.trim();
+    if (candidate) {
+      try {
+        // Throws if URL invalid
+        new URL(candidate);
+      } catch (error) {
+        setStatus(elements.healthStatus, "Enter a full URL including http(s)://", "error");
+        return;
+      }
+    }
+    setApiBase(candidate || "");
+    if (getApiBase()) {
+      refreshHealth();
+      loadProjects();
+    } else {
+      setStatus(elements.healthStatus, "Cleared API base. Set a new endpoint to continue.", "info");
+    }
+  });
+
+  elements.ingestForm.addEventListener("submit", handleIngest);
+  elements.refreshProjects.addEventListener("click", loadProjects);
+  elements.askForm.addEventListener("submit", handleAsk);
+  elements.askProjectId.addEventListener("change", (event) => setProjectId(event.target.value));
+  elements.ingestProjectId.addEventListener("change", (event) => setProjectId(event.target.value));
+}
+
+function bootstrap() {
+  cacheElements();
+  const params = new URLSearchParams(window.location.search);
+  const urlOverride = params.get("api");
+  const stored = localStorage.getItem("apiBase");
+  const initial = sanitizeBase(urlOverride || stored || DEFAULT_API_BASE);
+  try {
+    if (initial) {
+      new URL(initial);
+    }
+    setApiBase(initial);
+  } catch (error) {
+    setApiBase(DEFAULT_API_BASE);
+  }
+  const savedProjectId = localStorage.getItem("projectId");
+  if (savedProjectId) {
+    setProjectId(savedProjectId);
+  }
+  bindEvents();
+  if (getApiBase()) {
+    refreshHealth();
+    loadProjects();
+  } else {
+    setStatus(elements.healthStatus, "Set API base URL to get started.", "info");
+  }
+}
+
+document.addEventListener("DOMContentLoaded", bootstrap);

--- a/ui/web/index.html
+++ b/ui/web/index.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Construction Doc Copilot Web Client</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>👷 Construction Doc Copilot</h1>
+      <p>Browser client for the RAG backend. Point it at your FastAPI service and operate from anywhere.</p>
+    </header>
+
+    <main>
+      <section id="connection" class="panel">
+        <h2>Connect to API</h2>
+        <p class="hint">
+          Host the FastAPI service (port 8000 by default) behind HTTPS if you load this page via GitHub Pages or any HTTPS origin. Mixed content will be blocked by browsers.
+        </p>
+        <div class="control-group">
+          <label for="apiBase">API base URL</label>
+          <input id="apiBase" type="url" placeholder="https://your-api.example.com" autocomplete="off" />
+          <button id="saveApiBase" type="button">Save &amp; check status</button>
+        </div>
+        <p class="hint">Value is cached locally so returning operators reuse the same endpoint.</p>
+        <div class="status" id="healthStatus"></div>
+      </section>
+
+      <section id="ingest" class="panel">
+        <h2>Ingest documents</h2>
+        <form id="ingestForm">
+          <div class="control-group">
+            <label for="ingestProjectId">Project ID (optional)</label>
+            <input id="ingestProjectId" name="project_id" type="text" placeholder="Leave blank to auto-generate" />
+          </div>
+          <div class="control-group">
+            <label for="zipUpload">ZIP of PDFs</label>
+            <input id="zipUpload" name="zipfile" type="file" accept=".zip" />
+          </div>
+          <div class="control-group">
+            <label for="folderPath">Server-side folder path (optional)</label>
+            <input id="folderPath" name="folder_path" type="text" placeholder="/path/on/server/project_docs" />
+          </div>
+          <div class="control-group inline">
+            <label>
+              <input id="ocrToggle" name="ocr" type="checkbox" />
+              Enable OCR for scanned pages
+            </label>
+          </div>
+          <button type="submit">Send to API</button>
+        </form>
+        <div class="status" id="ingestStatus"></div>
+      </section>
+
+      <section id="projects" class="panel">
+        <h2>Tracked projects</h2>
+        <div class="control-group inline">
+          <button id="refreshProjects" type="button">Refresh list</button>
+        </div>
+        <div id="projectsTable" class="table"></div>
+      </section>
+
+      <section id="ask" class="panel">
+        <h2>Ask your documents</h2>
+        <form id="askForm">
+          <div class="control-group">
+            <label for="askProjectId">Project ID</label>
+            <input id="askProjectId" type="text" required placeholder="project id from ingest" />
+          </div>
+          <div class="control-group">
+            <label for="question">Question</label>
+            <input id="question" type="text" required placeholder="When is substantial completion required?" />
+          </div>
+          <div class="control-group">
+            <label for="topK">Top-K results</label>
+            <input id="topK" type="number" min="1" max="50" value="5" />
+          </div>
+          <button type="submit">Ask</button>
+        </form>
+        <div class="status" id="askStatus"></div>
+        <article id="answer"></article>
+      </section>
+    </main>
+
+    <footer>
+      <p>
+        Built for lightweight field deployments. Source lives alongside the Streamlit UI under <code>ui/web</code>.
+      </p>
+    </footer>
+
+    <template id="projectRowTemplate">
+      <div class="row">
+        <div class="cell project-id"></div>
+        <div class="cell doc-count"></div>
+        <div class="cell chunk-count"></div>
+        <div class="cell doc-list"></div>
+      </div>
+    </template>
+
+    <template id="citationTemplate">
+      <section class="citation">
+        <p class="citation-text"></p>
+        <img class="citation-preview" loading="lazy" alt="Document preview" />
+      </section>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/ui/web/styles.css
+++ b/ui/web/styles.css
@@ -1,0 +1,250 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", "Inter", system-ui, sans-serif;
+  line-height: 1.5;
+  font-size: 16px;
+  background-color: #0f172a;
+  color: #0b1120;
+}
+
+body {
+  margin: 0;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 60%, #0f172a 100%);
+  color: #0b1120;
+  min-height: 100vh;
+}
+
+header {
+  padding: 2rem 1.5rem 1rem;
+  text-align: center;
+  color: #e2e8f0;
+}
+
+header h1 {
+  margin: 0;
+  font-weight: 700;
+}
+
+header p {
+  margin: 0.5rem auto 0;
+  max-width: 720px;
+  color: #cbd5f5;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(248, 250, 252, 0.94);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.35rem;
+  color: #1f2937;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: #475569;
+  margin-bottom: 1rem;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.control-group.inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+input[type="text"],
+input[type="url"],
+input[type="number"],
+input[type="file"] {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(100, 116, 139, 0.6);
+  background: rgba(255, 255, 255, 0.92);
+  color: #0f172a;
+}
+
+input:focus {
+  outline: 2px solid #38bdf8;
+  border-color: transparent;
+}
+
+button {
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.35);
+}
+
+button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.status {
+  margin-top: 1rem;
+  font-size: 0.95rem;
+  min-height: 1.5rem;
+}
+
+.status.info {
+  color: #1d4ed8;
+}
+
+.status.success {
+  color: #047857;
+}
+
+.status.error {
+  color: #b91c1c;
+}
+
+.badge-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.badge.ok {
+  background: rgba(16, 185, 129, 0.15);
+  color: #047857;
+}
+
+.badge.warn {
+  background: rgba(251, 191, 36, 0.2);
+  color: #92400e;
+}
+
+.status .meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #334155;
+}
+
+.table {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1.5fr 0.7fr 0.7fr 2fr;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(241, 245, 249, 0.9);
+  border: 1px solid rgba(203, 213, 225, 0.6);
+}
+
+.cell {
+  font-size: 0.9rem;
+  color: #111827;
+  word-break: break-word;
+}
+
+.citation {
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.5);
+}
+
+.citation-text {
+  margin: 0 0 0.75rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.citation-preview {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: white;
+}
+
+#answer {
+  margin-top: 1rem;
+  background: rgba(248, 250, 252, 0.7);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(203, 213, 225, 0.5);
+}
+
+#answer h3 {
+  margin-top: 0;
+  color: #1e3a8a;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1.5rem 3rem;
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+code {
+  font-family: "Fira Code", "JetBrains Mono", monospace;
+  background: rgba(15, 23, 42, 0.1);
+  padding: 0.1rem 0.35rem;
+  border-radius: 6px;
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 0 1rem 3rem;
+  }
+
+  .row {
+    grid-template-columns: 1fr;
+  }
+
+  .control-group.inline {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static HTML/JS client under `ui/web` that can drive the FastAPI backend from any static host
- document how to publish the bundle to GitHub Pages and configure the API endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c899b01b9883288496f2c668f54e67